### PR TITLE
Call unwrap in macros

### DIFF
--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -60,14 +60,14 @@ macro_rules! coord {
     ($($index:expr),*) => {
         {
             use $crate::coordinate::Coordinate;
-            Coordinate::new(vec![$($index),*])
+            Coordinate::new(vec![$($index),*]).unwrap()
         }
     };
 
     ($index:expr; $count:expr) => {
         {
             use $crate::coordinate::Coordinate;
-            Coordinate::new(vec![$index; $count])
+            Coordinate::new(vec![$index; $count]).unwrap()
         }
     };
 }
@@ -78,13 +78,13 @@ mod tests {
 
     #[test]
     fn test_order() {
-        let coord = coord![1, 2, 3].unwrap();
+        let coord = coord![1, 2, 3];
         assert_eq!(coord.order(), 3);
     }
 
     #[test]
     fn test_iter() {
-        let coord = coord![1, 2, 3].unwrap();
+        let coord = coord![1, 2, 3];
         let mut iter = coord.iter();
         assert_eq!(iter.next(), Some(&1));
         assert_eq!(iter.next(), Some(&2));
@@ -94,14 +94,14 @@ mod tests {
 
     #[test]
     fn test_insert() {
-        let coord = coord![1, 2, 3].unwrap();
+        let coord = coord![1, 2, 3];
         let new_coord = coord.insert(1, 4);
-        assert_eq!(new_coord, coord![1, 4, 2, 3].unwrap());
+        assert_eq!(new_coord, coord![1, 4, 2, 3]);
     }
 
     #[test]
     fn test_index() {
-        let coord = coord![1, 2, 3].unwrap();
+        let coord = coord![1, 2, 3];
         assert_eq!(coord[0], 1);
         assert_eq!(coord[1], 2);
         assert_eq!(coord[2], 3);
@@ -109,23 +109,23 @@ mod tests {
 
     #[test]
     fn test_index_mut() {
-        let mut coord = coord![1, 2, 3].unwrap();
+        let mut coord = coord![1, 2, 3];
         coord[1] = 4;
         assert_eq!(coord[1], 4);
     }
 
     #[test]
     fn test_display() {
-        let coord = coord![1, 2, 3].unwrap();
+        let coord = coord![1, 2, 3];
         assert_eq!(format!("{}", coord), "(1, 2, 3)");
     }
 
     #[test]
     fn test_coord_macro() {
-        let coord = coord![1, 2, 3].unwrap();
+        let coord = coord![1, 2, 3];
         assert_eq!(coord, Coordinate::new(vec![1, 2, 3]).unwrap());
 
-        let coord_repeated = coord![1; 3].unwrap();
+        let coord_repeated = coord![1; 3];
         assert_eq!(coord_repeated, Coordinate::new(vec![1, 1, 1]).unwrap());
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -12,7 +12,7 @@ pub struct IndexIterator {
 impl IndexIterator {
     pub fn new(shape: &Shape) -> Self {
         // (shape.order() == 0) => `next` returns None before `current` is used
-        let current = coord![0; max(shape.order(), 1)].unwrap();
+        let current = coord![0; max(shape.order(), 1)];
         IndexIterator {
             shape: shape.clone(),
             current,
@@ -54,33 +54,33 @@ mod tests {
 
     #[test]
     fn test_index_iterator() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let mut iter = IndexIterator::new(&shape);
 
-        assert_eq!(iter.next(), Some(coord![0, 0].unwrap()));
-        assert_eq!(iter.next(), Some(coord![0, 1].unwrap()));
-        assert_eq!(iter.next(), Some(coord![0, 2].unwrap()));
-        assert_eq!(iter.next(), Some(coord![1, 0].unwrap()));
-        assert_eq!(iter.next(), Some(coord![1, 1].unwrap()));
-        assert_eq!(iter.next(), Some(coord![1, 2].unwrap()));
+        assert_eq!(iter.next(), Some(coord![0, 0]));
+        assert_eq!(iter.next(), Some(coord![0, 1]));
+        assert_eq!(iter.next(), Some(coord![0, 2]));
+        assert_eq!(iter.next(), Some(coord![1, 0]));
+        assert_eq!(iter.next(), Some(coord![1, 1]));
+        assert_eq!(iter.next(), Some(coord![1, 2]));
         assert_eq!(iter.next(), None);
     }
 
     #[test]
     fn test_index_iterator_single_dimension() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let mut iter = IndexIterator::new(&shape);
 
-        assert_eq!(iter.next(), Some(coord![0].unwrap()));
-        assert_eq!(iter.next(), Some(coord![1].unwrap()));
-        assert_eq!(iter.next(), Some(coord![2].unwrap()));
-        assert_eq!(iter.next(), Some(coord![3].unwrap()));
+        assert_eq!(iter.next(), Some(coord![0]));
+        assert_eq!(iter.next(), Some(coord![1]));
+        assert_eq!(iter.next(), Some(coord![2]));
+        assert_eq!(iter.next(), Some(coord![3]));
         assert_eq!(iter.next(), None);
     }
 
     #[test]
     fn test_index_iterator_empty_tensor() {
-        let shape = shape![].unwrap();
+        let shape = shape![];
         let mut iter = IndexIterator::new(&shape);
 
         assert_eq!(iter.next(), None);

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -36,7 +36,7 @@ impl<T: Num + PartialOrd + Copy> DynamicMatrix<T> {
     pub fn eye(shape: &Shape) -> Result<DynamicMatrix<T>, ShapeError> {
         let mut result = DynamicMatrix::zeros(shape).unwrap();
         for i in 0..shape[0] {
-            result.set(&coord![i, i].unwrap(), T::one()).unwrap();
+            result.set(&coord![i, i], T::one()).unwrap();
         }
         Ok(result)
     }
@@ -76,14 +76,14 @@ impl<T: Num + PartialOrd + Copy> DynamicMatrix<T> {
     pub fn matmul(&self, rhs: &Self) -> DynamicMatrix<T> {
         // Matrix-Matrix multiplication
         assert_eq!(self.shape()[1], rhs.shape()[0]);
-        let mut result = DynamicTensor::zeros(&shape![self.shape()[0], rhs.shape()[1]].unwrap());
+        let mut result = DynamicTensor::zeros(&shape![self.shape()[0], rhs.shape()[1]]);
         for i in 0..self.shape()[0] {
             for j in 0..rhs.shape()[1] {
                 let mut sum = T::zero();
                 for k in 0..self.shape()[1] {
-                    sum = sum + self[coord![i, k].unwrap()] * rhs[coord![k, j].unwrap()];
+                    sum = sum + self[coord![i, k]] * rhs[coord![k, j]];
                 }
-                result.set(&coord![i, j].unwrap(), sum).unwrap();
+                result.set(&coord![i, j], sum).unwrap();
             }
         }
         DynamicMatrix::from_tensor(result).unwrap()
@@ -91,13 +91,13 @@ impl<T: Num + PartialOrd + Copy> DynamicMatrix<T> {
 
     pub fn vecmul(&self, rhs: &DynamicVector<T>) -> DynamicVector<T> {
         assert_eq!(self.shape()[1], rhs.shape()[0]);
-        let mut result = DynamicTensor::zeros(&shape![self.shape()[0]].unwrap());
+        let mut result = DynamicTensor::zeros(&shape![self.shape()[0]]);
         for i in 0..self.shape()[0] {
             let mut sum = T::zero();
             for j in 0..self.shape()[1] {
-                sum = sum + self[coord![i, j].unwrap()] * rhs[j];
+                sum = sum + self[coord![i, j]] * rhs[j];
             }
-            result.set(&coord![i].unwrap(), sum).unwrap();
+            result.set(&coord![i], sum).unwrap();
         }
         DynamicVector::from_tensor(result).unwrap()
     }
@@ -247,32 +247,32 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         assert_eq!(matrix.shape(), &shape);
-        assert_eq!(matrix[coord![0, 0].unwrap()], 1.0);
-        assert_eq!(matrix[coord![0, 1].unwrap()], 2.0);
-        assert_eq!(matrix[coord![1, 0].unwrap()], 3.0);
-        assert_eq!(matrix[coord![1, 1].unwrap()], 4.0);
+        assert_eq!(matrix[coord![0, 0]], 1.0);
+        assert_eq!(matrix[coord![0, 1]], 2.0);
+        assert_eq!(matrix[coord![1, 0]], 3.0);
+        assert_eq!(matrix[coord![1, 1]], 4.0);
     }
 
     #[test]
     fn test_from_tensor() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = DynamicTensor::new(&shape, &data).unwrap();
         let matrix = DynamicMatrix::from_tensor(tensor).unwrap();
         assert_eq!(matrix.shape(), &shape);
-        assert_eq!(matrix[coord![0, 0].unwrap()], 1.0);
-        assert_eq!(matrix[coord![0, 1].unwrap()], 2.0);
-        assert_eq!(matrix[coord![1, 0].unwrap()], 3.0);
-        assert_eq!(matrix[coord![1, 1].unwrap()], 4.0);
+        assert_eq!(matrix[coord![0, 0]], 1.0);
+        assert_eq!(matrix[coord![0, 1]], 2.0);
+        assert_eq!(matrix[coord![1, 0]], 3.0);
+        assert_eq!(matrix[coord![1, 1]], 4.0);
     }
 
     #[test]
     fn test_from_tensor_fail() {
-        let shape = shape![2, 2, 2].unwrap();
+        let shape = shape![2, 2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let tensor = DynamicTensor::new(&shape, &data).unwrap();
         let result = DynamicMatrix::from_tensor(tensor);
@@ -281,377 +281,377 @@ mod tests {
 
     #[test]
     fn test_fill() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let matrix = DynamicMatrix::fill(&shape, 3.0).unwrap();
         assert_eq!(matrix.shape(), &shape);
-        assert_eq!(matrix[coord![0, 0].unwrap()], 3.0);
-        assert_eq!(matrix[coord![0, 1].unwrap()], 3.0);
-        assert_eq!(matrix[coord![1, 0].unwrap()], 3.0);
-        assert_eq!(matrix[coord![1, 1].unwrap()], 3.0);
+        assert_eq!(matrix[coord![0, 0]], 3.0);
+        assert_eq!(matrix[coord![0, 1]], 3.0);
+        assert_eq!(matrix[coord![1, 0]], 3.0);
+        assert_eq!(matrix[coord![1, 1]], 3.0);
     }
 
     #[test]
     fn test_eye() {
-        let shape = shape![3, 3].unwrap();
+        let shape = shape![3, 3];
         let matrix = DynamicMatrix::<f64>::eye(&shape).unwrap();
         assert_eq!(matrix.shape(), &shape);
-        assert_eq!(matrix[coord![0, 0].unwrap()], 1.0);
-        assert_eq!(matrix[coord![0, 1].unwrap()], 0.0);
-        assert_eq!(matrix[coord![0, 2].unwrap()], 0.0);
-        assert_eq!(matrix[coord![1, 0].unwrap()], 0.0);
-        assert_eq!(matrix[coord![1, 1].unwrap()], 1.0);
-        assert_eq!(matrix[coord![1, 2].unwrap()], 0.0);
-        assert_eq!(matrix[coord![2, 0].unwrap()], 0.0);
-        assert_eq!(matrix[coord![2, 1].unwrap()], 0.0);
-        assert_eq!(matrix[coord![2, 2].unwrap()], 1.0);
+        assert_eq!(matrix[coord![0, 0]], 1.0);
+        assert_eq!(matrix[coord![0, 1]], 0.0);
+        assert_eq!(matrix[coord![0, 2]], 0.0);
+        assert_eq!(matrix[coord![1, 0]], 0.0);
+        assert_eq!(matrix[coord![1, 1]], 1.0);
+        assert_eq!(matrix[coord![1, 2]], 0.0);
+        assert_eq!(matrix[coord![2, 0]], 0.0);
+        assert_eq!(matrix[coord![2, 1]], 0.0);
+        assert_eq!(matrix[coord![2, 2]], 1.0);
     }
 
     #[test]
     fn test_zeros() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let matrix = DynamicMatrix::<f64>::zeros(&shape).unwrap();
         assert_eq!(matrix.shape(), &shape);
-        assert_eq!(matrix[coord![0, 0].unwrap()], 0.0);
-        assert_eq!(matrix[coord![0, 1].unwrap()], 0.0);
-        assert_eq!(matrix[coord![1, 0].unwrap()], 0.0);
-        assert_eq!(matrix[coord![1, 1].unwrap()], 0.0);
+        assert_eq!(matrix[coord![0, 0]], 0.0);
+        assert_eq!(matrix[coord![0, 1]], 0.0);
+        assert_eq!(matrix[coord![1, 0]], 0.0);
+        assert_eq!(matrix[coord![1, 1]], 0.0);
     }
 
     #[test]
     fn test_ones() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let matrix = DynamicMatrix::<f64>::ones(&shape).unwrap();
         assert_eq!(matrix.shape(), &shape);
-        assert_eq!(matrix[coord![0, 0].unwrap()], 1.0);
-        assert_eq!(matrix[coord![0, 1].unwrap()], 1.0);
-        assert_eq!(matrix[coord![1, 0].unwrap()], 1.0);
-        assert_eq!(matrix[coord![1, 1].unwrap()], 1.0);
+        assert_eq!(matrix[coord![0, 0]], 1.0);
+        assert_eq!(matrix[coord![0, 1]], 1.0);
+        assert_eq!(matrix[coord![1, 0]], 1.0);
+        assert_eq!(matrix[coord![1, 1]], 1.0);
     }
 
     #[test]
     fn test_size() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let matrix = DynamicMatrix::<f64>::zeros(&shape).unwrap();
         assert_eq!(matrix.size(), 4);
     }
 
     #[test]
     fn test_get() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
-        assert_eq!(matrix[coord![1, 0].unwrap()], 3.0);
+        assert_eq!(matrix[coord![1, 0]], 3.0);
     }
 
     #[test]
     fn test_get_mut() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let mut matrix = DynamicMatrix::new(&shape, &data).unwrap();
-        matrix[coord![1, 0].unwrap()] = 5.0;
+        matrix[coord![1, 0]] = 5.0;
         assert_eq!(matrix.shape(), &shape);
-        assert_eq!(matrix[coord![0, 0].unwrap()], 1.0);
-        assert_eq!(matrix[coord![0, 1].unwrap()], 2.0);
-        assert_eq!(matrix[coord![1, 0].unwrap()], 5.0);
-        assert_eq!(matrix[coord![1, 1].unwrap()], 4.0);
+        assert_eq!(matrix[coord![0, 0]], 1.0);
+        assert_eq!(matrix[coord![0, 1]], 2.0);
+        assert_eq!(matrix[coord![1, 0]], 5.0);
+        assert_eq!(matrix[coord![1, 1]], 4.0);
     }
 
     #[test]
     fn test_set() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let mut matrix = DynamicMatrix::new(&shape, &data).unwrap();
-        matrix.set(&coord![1, 0].unwrap(), 5.0).unwrap();
+        matrix.set(&coord![1, 0], 5.0).unwrap();
         assert_eq!(matrix.shape(), &shape);
-        assert_eq!(matrix[coord![0, 0].unwrap()], 1.0);
-        assert_eq!(matrix[coord![0, 1].unwrap()], 2.0);
-        assert_eq!(matrix[coord![1, 0].unwrap()], 5.0);
-        assert_eq!(matrix[coord![1, 1].unwrap()], 4.0);
+        assert_eq!(matrix[coord![0, 0]], 1.0);
+        assert_eq!(matrix[coord![0, 1]], 2.0);
+        assert_eq!(matrix[coord![1, 0]], 5.0);
+        assert_eq!(matrix[coord![1, 1]], 4.0);
     }
 
     #[test]
     fn test_sum() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         let result = matrix.sum(vec![0, 1]);
         assert_eq!(result[0], 10.0);
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
     }
 
     #[test]
     fn test_mean() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         let result = matrix.mean(vec![0, 1]);
         assert_eq!(result[0], 2.5);
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
     }
 
     #[test]
     fn test_var() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         let result = matrix.var(vec![0, 1]);
         assert_eq!(result[0], 1.25);
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
     }
 
     #[test]
     fn test_min() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         let result = matrix.min(vec![0, 1]);
         assert_eq!(result[0], 1.0);
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
     }
 
     #[test]
     fn test_max() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![-1.0, -2.0, -3.0, -4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         let result = matrix.max(vec![0, 1]);
         assert_eq!(result[0], -1.0);
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
     }
 
     #[test]
     fn test_matmul() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let matrix1 = DynamicMatrix::new(&shape, &data1).unwrap();
         let matrix2 = DynamicMatrix::new(&shape, &data2).unwrap();
         let result = matrix1.matmul(&matrix2);
         assert_eq!(result.shape(), &shape);
-        assert_eq!(result[coord![0, 0].unwrap()], 10.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 13.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 22.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 29.0);
+        assert_eq!(result[coord![0, 0]], 10.0);
+        assert_eq!(result[coord![0, 1]], 13.0);
+        assert_eq!(result[coord![1, 0]], 22.0);
+        assert_eq!(result[coord![1, 1]], 29.0);
     }
 
     #[test]
     fn test_vecmul() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         let vector_data = vec![1.0, 2.0];
         let vector = DynamicVector::new(&vector_data).unwrap();
         let result = matrix.vecmul(&vector);
-        assert_eq!(result.shape(), &shape![2].unwrap());
+        assert_eq!(result.shape(), &shape![2]);
         assert_eq!(result[0], 5.0);
         assert_eq!(result[1], 11.0);
     }
 
     #[test]
     fn test_add_scalar() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         let result = matrix + 2.0;
-        assert_eq!(result[coord![0, 0].unwrap()], 3.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 4.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 5.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 6.0);
+        assert_eq!(result[coord![0, 0]], 3.0);
+        assert_eq!(result[coord![0, 1]], 4.0);
+        assert_eq!(result[coord![1, 0]], 5.0);
+        assert_eq!(result[coord![1, 1]], 6.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_add_matrix() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let matrix1 = DynamicMatrix::new(&shape, &data1).unwrap();
         let matrix2 = DynamicMatrix::new(&shape, &data2).unwrap();
         let result = matrix1 + matrix2;
-        assert_eq!(result[coord![0, 0].unwrap()], 3.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 5.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 7.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 9.0);
+        assert_eq!(result[coord![0, 0]], 3.0);
+        assert_eq!(result[coord![0, 1]], 5.0);
+        assert_eq!(result[coord![1, 0]], 7.0);
+        assert_eq!(result[coord![1, 1]], 9.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_add_matrix_tensor() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let matrix = DynamicMatrix::new(&shape, &data1).unwrap();
         let tensor = DynamicTensor::new(&shape, &data2).unwrap();
         let result = matrix + tensor;
-        assert_eq!(result[coord![0, 0].unwrap()], 3.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 5.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 7.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 9.0);
+        assert_eq!(result[coord![0, 0]], 3.0);
+        assert_eq!(result[coord![0, 1]], 5.0);
+        assert_eq!(result[coord![1, 0]], 7.0);
+        assert_eq!(result[coord![1, 1]], 9.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_sub_scalar() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         let result = matrix - 2.0;
-        assert_eq!(result[coord![0, 0].unwrap()], -1.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 0.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 1.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 2.0);
+        assert_eq!(result[coord![0, 0]], -1.0);
+        assert_eq!(result[coord![0, 1]], 0.0);
+        assert_eq!(result[coord![1, 0]], 1.0);
+        assert_eq!(result[coord![1, 1]], 2.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_sub_matrix() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let matrix1 = DynamicMatrix::new(&shape, &data1).unwrap();
         let matrix2 = DynamicMatrix::new(&shape, &data2).unwrap();
         let result = matrix1 - matrix2;
-        assert_eq!(result[coord![0, 0].unwrap()], -1.0);
-        assert_eq!(result[coord![0, 1].unwrap()], -1.0);
-        assert_eq!(result[coord![1, 0].unwrap()], -1.0);
-        assert_eq!(result[coord![1, 1].unwrap()], -1.0);
+        assert_eq!(result[coord![0, 0]], -1.0);
+        assert_eq!(result[coord![0, 1]], -1.0);
+        assert_eq!(result[coord![1, 0]], -1.0);
+        assert_eq!(result[coord![1, 1]], -1.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_sub_matrix_tensor() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let matrix = DynamicMatrix::new(&shape, &data1).unwrap();
         let tensor = DynamicTensor::new(&shape, &data2).unwrap();
         let result = matrix - tensor;
-        assert_eq!(result[coord![0, 0].unwrap()], -1.0);
-        assert_eq!(result[coord![0, 1].unwrap()], -1.0);
-        assert_eq!(result[coord![1, 0].unwrap()], -1.0);
-        assert_eq!(result[coord![1, 1].unwrap()], -1.0);
+        assert_eq!(result[coord![0, 0]], -1.0);
+        assert_eq!(result[coord![0, 1]], -1.0);
+        assert_eq!(result[coord![1, 0]], -1.0);
+        assert_eq!(result[coord![1, 1]], -1.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_mul_scalar() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         let result = matrix * 2.0;
-        assert_eq!(result[coord![0, 0].unwrap()], 2.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 4.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 6.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 8.0);
+        assert_eq!(result[coord![0, 0]], 2.0);
+        assert_eq!(result[coord![0, 1]], 4.0);
+        assert_eq!(result[coord![1, 0]], 6.0);
+        assert_eq!(result[coord![1, 1]], 8.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_mul_matrix() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let matrix1 = DynamicMatrix::new(&shape, &data1).unwrap();
         let matrix2 = DynamicMatrix::new(&shape, &data2).unwrap();
         let result = matrix1 * matrix2;
-        assert_eq!(result[coord![0, 0].unwrap()], 2.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 6.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 12.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 20.0);
+        assert_eq!(result[coord![0, 0]], 2.0);
+        assert_eq!(result[coord![0, 1]], 6.0);
+        assert_eq!(result[coord![1, 0]], 12.0);
+        assert_eq!(result[coord![1, 1]], 20.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_mul_matrix_tensor() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let matrix = DynamicMatrix::new(&shape, &data1).unwrap();
         let tensor = DynamicTensor::new(&shape, &data2).unwrap();
         let result = matrix * tensor;
-        assert_eq!(result[coord![0, 0].unwrap()], 2.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 6.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 12.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 20.0);
+        assert_eq!(result[coord![0, 0]], 2.0);
+        assert_eq!(result[coord![0, 1]], 6.0);
+        assert_eq!(result[coord![1, 0]], 12.0);
+        assert_eq!(result[coord![1, 1]], 20.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_div_scalar() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![4.0, 6.0, 8.0, 10.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         let result = matrix / 2.0;
-        assert_eq!(result[coord![0, 0].unwrap()], 2.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 3.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 4.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 5.0);
+        assert_eq!(result[coord![0, 0]], 2.0);
+        assert_eq!(result[coord![0, 1]], 3.0);
+        assert_eq!(result[coord![1, 0]], 4.0);
+        assert_eq!(result[coord![1, 1]], 5.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_div_matrix() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![4.0, 6.0, 8.0, 10.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let matrix1 = DynamicMatrix::new(&shape, &data1).unwrap();
         let matrix2 = DynamicMatrix::new(&shape, &data2).unwrap();
         let result = matrix1 / matrix2;
-        assert_eq!(result[coord![0, 0].unwrap()], 2.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 2.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 2.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 2.0);
+        assert_eq!(result[coord![0, 0]], 2.0);
+        assert_eq!(result[coord![0, 1]], 2.0);
+        assert_eq!(result[coord![1, 0]], 2.0);
+        assert_eq!(result[coord![1, 1]], 2.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_div_matrix_tensor() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![4.0, 6.0, 8.0, 10.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let matrix = DynamicMatrix::new(&shape, &data1).unwrap();
         let tensor = DynamicTensor::new(&shape, &data2).unwrap();
         let result = matrix / tensor;
-        assert_eq!(result[coord![0, 0].unwrap()], 2.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 2.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 2.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 2.0);
+        assert_eq!(result[coord![0, 0]], 2.0);
+        assert_eq!(result[coord![0, 1]], 2.0);
+        assert_eq!(result[coord![1, 0]], 2.0);
+        assert_eq!(result[coord![1, 1]], 2.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_index_coord() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
-        assert_eq!(matrix[coord![0, 0].unwrap()], 1.0);
-        assert_eq!(matrix[coord![0, 1].unwrap()], 2.0);
-        assert_eq!(matrix[coord![1, 0].unwrap()], 3.0);
-        assert_eq!(matrix[coord![1, 1].unwrap()], 4.0);
+        assert_eq!(matrix[coord![0, 0]], 1.0);
+        assert_eq!(matrix[coord![0, 1]], 2.0);
+        assert_eq!(matrix[coord![1, 0]], 3.0);
+        assert_eq!(matrix[coord![1, 1]], 4.0);
     }
 
     #[test]
     fn test_index_mut_coord() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let mut matrix = DynamicMatrix::new(&shape, &data).unwrap();
-        matrix[coord![0, 0].unwrap()] = 5.0;
-        assert_eq!(matrix[coord![0, 0].unwrap()], 5.0);
-        assert_eq!(matrix[coord![0, 1].unwrap()], 2.0);
-        assert_eq!(matrix[coord![1, 0].unwrap()], 3.0);
-        assert_eq!(matrix[coord![1, 1].unwrap()], 4.0);
+        matrix[coord![0, 0]] = 5.0;
+        assert_eq!(matrix[coord![0, 0]], 5.0);
+        assert_eq!(matrix[coord![0, 1]], 2.0);
+        assert_eq!(matrix[coord![1, 0]], 3.0);
+        assert_eq!(matrix[coord![1, 1]], 4.0);
     }
 
     #[test]
     fn test_pow_matrix() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![2.0, 3.0, 4.0, 5.0];
         let matrix = DynamicMatrix::new(&shape, &data).unwrap();
         let result = matrix.pow(2.0);
-        assert_eq!(result[coord![0, 0].unwrap()], 4.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 9.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 16.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 25.0);
+        assert_eq!(result[coord![0, 0]], 4.0);
+        assert_eq!(result[coord![0, 1]], 9.0);
+        assert_eq!(result[coord![1, 0]], 16.0);
+        assert_eq!(result[coord![1, 1]], 25.0);
         assert_eq!(result.shape(), &shape);
     }
 }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -60,7 +60,7 @@ macro_rules! shape {
     ($($dim:expr),*) => {
         {
             use $crate::shape::Shape;
-            Shape::new(vec![$($dim),*])
+            Shape::new(vec![$($dim),*]).unwrap()
         }
     };
 }
@@ -97,10 +97,10 @@ mod tests {
 
     #[test]
     fn test_shape_macro() {
-        let shape = shape![2, 3, 4].unwrap();
+        let shape = shape![2, 3, 4];
         assert_eq!(shape.dims, vec![2, 3, 4]);
 
-        let shape = shape![1].unwrap();
+        let shape = shape![1];
         assert_eq!(shape.dims, vec![1]);
     }
 

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -83,7 +83,7 @@ impl<T: Num + PartialOrd + Copy> Tensor<T> {
         // We resolve to a scalar value
         if axes.is_empty() | remaining_dims.is_empty() {
             let sum: T = self.data.iter().fold(T::zero(), |acc, x| acc + *x);
-            return Tensor::new(&shape![1].unwrap(), &[sum]).unwrap();
+            return Tensor::new(&shape![1], &[sum]).unwrap();
         }
 
         // Create new tensor with right shape
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn test_new_tensor() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
 
         let tensor = Tensor::new(&shape, &data).unwrap();
@@ -568,7 +568,7 @@ mod tests {
 
     #[test]
     fn test_new_tensor_shape_data_mismatch() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0]; // Mismatched data length
 
         let result = Tensor::new(&shape, &data);
@@ -578,7 +578,7 @@ mod tests {
 
     #[test]
     fn test_zeros_tensor() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let tensor: Tensor<f32> = Tensor::zeros(&shape);
 
         assert_eq!(tensor.shape(), &shape);
@@ -587,7 +587,7 @@ mod tests {
 
     #[test]
     fn test_ones_tensor() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let tensor: Tensor<f32> = Tensor::ones(&shape);
 
         assert_eq!(tensor.shape(), &shape);
@@ -596,7 +596,7 @@ mod tests {
 
     #[test]
     fn test_fill_tensor() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let tensor: Tensor<f32> = Tensor::fill(&shape, 7.0);
 
         assert_eq!(tensor.shape(), &shape);
@@ -605,7 +605,7 @@ mod tests {
 
     #[test]
     fn test_tensor_shape() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let tensor: Tensor<f32> = Tensor::zeros(&shape);
 
         assert_eq!(tensor.shape(), &shape);
@@ -613,7 +613,7 @@ mod tests {
 
     #[test]
     fn test_tensor_size() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let tensor: Tensor<f32> = Tensor::zeros(&shape);
 
         assert_eq!(tensor.size(), 6);
@@ -621,82 +621,82 @@ mod tests {
 
     #[test]
     fn test_tensor_get() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
-        assert_eq!(*tensor.get(&coord![0, 0].unwrap()).unwrap(), 1.0);
-        assert_eq!(*tensor.get(&coord![0, 1].unwrap()).unwrap(), 2.0);
-        assert_eq!(*tensor.get(&coord![1, 0].unwrap()).unwrap(), 3.0);
-        assert_eq!(*tensor.get(&coord![1, 1].unwrap()).unwrap(), 4.0);
+        assert_eq!(*tensor.get(&coord![0, 0]).unwrap(), 1.0);
+        assert_eq!(*tensor.get(&coord![0, 1]).unwrap(), 2.0);
+        assert_eq!(*tensor.get(&coord![1, 0]).unwrap(), 3.0);
+        assert_eq!(*tensor.get(&coord![1, 1]).unwrap(), 4.0);
     }
 
     #[test]
     fn test_tensor_set() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let mut tensor = Tensor::new(&shape, &data).unwrap();
 
-        tensor.set(&coord![0, 0].unwrap(), 5.0).unwrap();
-        tensor.set(&coord![0, 1].unwrap(), 6.0).unwrap();
-        tensor.set(&coord![1, 0].unwrap(), 7.0).unwrap();
-        tensor.set(&coord![1, 1].unwrap(), 8.0).unwrap();
+        tensor.set(&coord![0, 0], 5.0).unwrap();
+        tensor.set(&coord![0, 1], 6.0).unwrap();
+        tensor.set(&coord![1, 0], 7.0).unwrap();
+        tensor.set(&coord![1, 1], 8.0).unwrap();
 
-        assert_eq!(*tensor.get(&coord![0, 0].unwrap()).unwrap(), 5.0);
-        assert_eq!(*tensor.get(&coord![0, 1].unwrap()).unwrap(), 6.0);
-        assert_eq!(*tensor.get(&coord![1, 0].unwrap()).unwrap(), 7.0);
-        assert_eq!(*tensor.get(&coord![1, 1].unwrap()).unwrap(), 8.0);
+        assert_eq!(*tensor.get(&coord![0, 0]).unwrap(), 5.0);
+        assert_eq!(*tensor.get(&coord![0, 1]).unwrap(), 6.0);
+        assert_eq!(*tensor.get(&coord![1, 0]).unwrap(), 7.0);
+        assert_eq!(*tensor.get(&coord![1, 1]).unwrap(), 8.0);
     }
 
     #[test]
     fn test_tensor_get_out_of_bounds() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
-        assert!(tensor.get(&coord![2, 0].unwrap()).is_err());
-        assert!(tensor.get(&coord![0, 2].unwrap()).is_err());
-        assert!(tensor.get(&coord![2, 2].unwrap()).is_err());
+        assert!(tensor.get(&coord![2, 0]).is_err());
+        assert!(tensor.get(&coord![0, 2]).is_err());
+        assert!(tensor.get(&coord![2, 2]).is_err());
     }
 
     #[test]
     fn test_tensor_set_out_of_bounds() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let mut tensor = Tensor::new(&shape, &data).unwrap();
 
-        assert!(tensor.set(&coord![2, 0].unwrap(), 5.0).is_err());
-        assert!(tensor.set(&coord![0, 2].unwrap(), 6.0).is_err());
-        assert!(tensor.set(&coord![2, 2].unwrap(), 7.0).is_err());
+        assert!(tensor.set(&coord![2, 0], 5.0).is_err());
+        assert!(tensor.set(&coord![0, 2], 6.0).is_err());
+        assert!(tensor.set(&coord![2, 2], 7.0).is_err());
     }
 
     #[test]
     fn test_tensor_sum_no_axis_1d() {
-        let shape = shape![5].unwrap();
+        let shape = shape![5];
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.sum(vec![]);
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![15.0]));
     }
 
     #[test]
     fn test_tensor_sum_no_axis_2d() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.sum(vec![]);
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![21.0]));
     }
 
     #[test]
     fn test_tensor_sum_no_axis_3d() {
-        let shape = shape![2, 2, 3].unwrap();
+        let shape = shape![2, 2, 3];
         let data = vec![
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
         ];
@@ -704,37 +704,37 @@ mod tests {
 
         let result = tensor.sum(vec![]);
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![78.0]));
     }
 
     #[test]
     fn test_tensor_sum_one_axis_1d() {
-        let shape = shape![5].unwrap();
+        let shape = shape![5];
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.sum(vec![0]);
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![15.0]));
     }
 
     #[test]
     fn test_tensor_sum_one_axis_2d() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.sum(vec![0]);
 
-        assert_eq!(result.shape(), &shape![3].unwrap());
+        assert_eq!(result.shape(), &shape![3]);
         assert_eq!(result.data, DynamicStorage::new(vec![5.0, 7.0, 9.0]));
     }
 
     #[test]
     fn test_tensor_sum_one_axis_3d() {
-        let shape = shape![2, 2, 3].unwrap();
+        let shape = shape![2, 2, 3];
         let data = vec![
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
         ];
@@ -742,7 +742,7 @@ mod tests {
 
         let result = tensor.sum(vec![0]);
 
-        assert_eq!(result.shape(), &shape![2, 3].unwrap());
+        assert_eq!(result.shape(), &shape![2, 3]);
         assert_eq!(
             result.data,
             DynamicStorage::new(vec![8.0, 10.0, 12.0, 14.0, 16.0, 18.0])
@@ -751,19 +751,19 @@ mod tests {
 
     #[test]
     fn test_tensor_sum_multiple_axes_2d() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.sum(vec![0, 1]);
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![21.0]));
     }
 
     #[test]
     fn test_tensor_sum_multiple_axes_3d() {
-        let shape = shape![2, 2, 3].unwrap();
+        let shape = shape![2, 2, 3];
         let data = vec![
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
         ];
@@ -771,37 +771,37 @@ mod tests {
 
         let result = tensor.sum(vec![0, 1]);
 
-        assert_eq!(result.shape(), &shape![3].unwrap());
+        assert_eq!(result.shape(), &shape![3]);
         assert_eq!(result.data, DynamicStorage::new(vec![22.0, 26.0, 30.0]));
     }
 
     #[test]
     fn test_tensor_mean_no_axis_2d() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.mean(vec![]);
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![3.5]));
     }
 
     #[test]
     fn test_tensor_mean_one_axis_2d() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.mean(vec![0]);
 
-        assert_eq!(result.shape(), &shape![3].unwrap());
+        assert_eq!(result.shape(), &shape![3]);
         assert_eq!(result.data, DynamicStorage::new(vec![2.5, 3.5, 4.5]));
     }
 
     #[test]
     fn test_tensor_mean_one_axis_3d() {
-        let shape = shape![2, 2, 3].unwrap();
+        let shape = shape![2, 2, 3];
         let data = vec![
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
         ];
@@ -809,7 +809,7 @@ mod tests {
 
         let result = tensor.mean(vec![0]);
 
-        assert_eq!(result.shape(), &shape![2, 3].unwrap());
+        assert_eq!(result.shape(), &shape![2, 3]);
         assert_eq!(
             result.data,
             DynamicStorage::new(vec![4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
@@ -818,19 +818,19 @@ mod tests {
 
     #[test]
     fn test_tensor_mean_multiple_axes_2d() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.mean(vec![0, 1]);
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![3.5]));
     }
 
     #[test]
     fn test_tensor_mean_multiple_axes_3d() {
-        let shape = shape![2, 2, 3].unwrap();
+        let shape = shape![2, 2, 3];
         let data = vec![
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
         ];
@@ -838,37 +838,37 @@ mod tests {
 
         let result = tensor.mean(vec![0, 1]);
 
-        assert_eq!(result.shape(), &shape![3].unwrap());
+        assert_eq!(result.shape(), &shape![3]);
         assert_eq!(result.data, DynamicStorage::new(vec![5.5, 6.5, 7.5]));
     }
 
     #[test]
     fn test_tensor_var_no_axis_2d() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let data = vec![1.0, 1.0, 1.0, 7.0, 7.0, 7.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.var(vec![]);
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![9.0]));
     }
 
     #[test]
     fn test_tensor_var_one_axis_2d() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.var(vec![0]);
 
-        assert_eq!(result.shape(), &shape![3].unwrap());
+        assert_eq!(result.shape(), &shape![3]);
         assert_eq!(result.data, DynamicStorage::new(vec![2.25, 2.25, 2.25]));
     }
 
     #[test]
     fn test_tensor_var_one_axis_3d() {
-        let shape = shape![2, 2, 3].unwrap();
+        let shape = shape![2, 2, 3];
         let data = vec![
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
         ];
@@ -876,7 +876,7 @@ mod tests {
 
         let result = tensor.var(vec![0]);
 
-        assert_eq!(result.shape(), &shape![2, 3].unwrap());
+        assert_eq!(result.shape(), &shape![2, 3]);
         assert_eq!(
             result.data,
             DynamicStorage::new(vec![9.0, 9.0, 9.0, 9.0, 9.0, 9.0])
@@ -885,19 +885,19 @@ mod tests {
 
     #[test]
     fn test_tensor_var_multiple_axes_2d() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let data = vec![1.0, 1.0, 1.0, 7.0, 7.0, 7.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.var(vec![0, 1]);
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![9.0]));
     }
 
     #[test]
     fn test_tensor_var_multiple_axes_3d() {
-        let shape = shape![2, 2, 3].unwrap();
+        let shape = shape![2, 2, 3];
         let data = vec![
             1.0, 3.0, 5.0, 7.0, 9.0, 11.0, 13.0, 15.0, 17.0, 19.0, 21.0, 23.0,
         ];
@@ -905,37 +905,37 @@ mod tests {
 
         let result = tensor.var(vec![0, 1]);
 
-        assert_eq!(result.shape(), &shape![3].unwrap());
+        assert_eq!(result.shape(), &shape![3]);
         assert_eq!(result.data, DynamicStorage::new(vec![45.0, 45.0, 45.0]));
     }
 
     #[test]
     fn test_tensor_max_no_axis_1d() {
-        let shape = shape![5].unwrap();
+        let shape = shape![5];
         let data = vec![1.0, -2.0, 3.0, -4.0, 5.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.max(vec![]);
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![5.0]));
     }
 
     #[test]
     fn test_tensor_max_one_axis_2d() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let data = vec![1.0, -2.0, 3.0, -4.0, 5.0, -6.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.max(vec![0]);
 
-        assert_eq!(result.shape(), &shape![3].unwrap());
+        assert_eq!(result.shape(), &shape![3]);
         assert_eq!(result.data, DynamicStorage::new(vec![1.0, 5.0, 3.0]));
     }
 
     #[test]
     fn test_tensor_max_multiple_axes_3d() {
-        let shape = shape![2, 2, 3].unwrap();
+        let shape = shape![2, 2, 3];
         let data = vec![
             1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0, 11.0, -12.0,
         ];
@@ -943,37 +943,37 @@ mod tests {
 
         let result = tensor.max(vec![0, 1]);
 
-        assert_eq!(result.shape(), &shape![3].unwrap());
+        assert_eq!(result.shape(), &shape![3]);
         assert_eq!(result.data, DynamicStorage::new(vec![7.0, 11.0, 9.0]));
     }
 
     #[test]
     fn test_tensor_min_no_axis_1d() {
-        let shape = shape![5].unwrap();
+        let shape = shape![5];
         let data = vec![1.0, -2.0, 3.0, -4.0, 5.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.min(vec![]);
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![-4.0]));
     }
 
     #[test]
     fn test_tensor_min_one_axis_2d() {
-        let shape = shape![2, 3].unwrap();
+        let shape = shape![2, 3];
         let data = vec![1.0, -2.0, 3.0, -4.0, 5.0, -6.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
 
         let result = tensor.min(vec![0]);
 
-        assert_eq!(result.shape(), &shape![3].unwrap());
+        assert_eq!(result.shape(), &shape![3]);
         assert_eq!(result.data, DynamicStorage::new(vec![-4.0, -2.0, -6.0]));
     }
 
     #[test]
     fn test_tensor_min_multiple_axes_3d() {
-        let shape = shape![2, 2, 3].unwrap();
+        let shape = shape![2, 2, 3];
         let data = vec![
             1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0, 11.0, -12.0,
         ];
@@ -981,23 +981,23 @@ mod tests {
 
         let result = tensor.min(vec![0, 1]);
 
-        assert_eq!(result.shape(), &shape![3].unwrap());
+        assert_eq!(result.shape(), &shape![3]);
         assert_eq!(result.data, DynamicStorage::new(vec![-10.0, -8.0, -12.0]));
     }
 
     #[test]
     fn test_tensor_prod_1d_1d() {
-        let shape1 = shape![3].unwrap();
+        let shape1 = shape![3];
         let data1 = vec![1.0, 2.0, 3.0];
         let tensor1 = Tensor::new(&shape1, &data1).unwrap();
 
-        let shape2 = shape![2].unwrap();
+        let shape2 = shape![2];
         let data2 = vec![4.0, 5.0];
         let tensor2 = Tensor::new(&shape2, &data2).unwrap();
 
         let result = tensor1.prod(&tensor2);
 
-        assert_eq!(result.shape(), &shape![3, 2].unwrap());
+        assert_eq!(result.shape(), &shape![3, 2]);
         assert_eq!(
             result.data,
             DynamicStorage::new(vec![4.0, 5.0, 8.0, 10.0, 12.0, 15.0])
@@ -1006,17 +1006,17 @@ mod tests {
 
     #[test]
     fn test_tensor_prod_2d_1d() {
-        let shape1 = shape![2, 2].unwrap();
+        let shape1 = shape![2, 2];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let tensor1 = Tensor::new(&shape1, &data1).unwrap();
 
-        let shape2 = shape![2].unwrap();
+        let shape2 = shape![2];
         let data2 = vec![5.0, 6.0];
         let tensor2 = Tensor::new(&shape2, &data2).unwrap();
 
         let result = tensor1.prod(&tensor2);
 
-        assert_eq!(result.shape(), &shape![2, 2, 2].unwrap());
+        assert_eq!(result.shape(), &shape![2, 2, 2]);
         assert_eq!(
             result.data,
             DynamicStorage::new(vec![5.0, 6.0, 10.0, 12.0, 15.0, 18.0, 20.0, 24.0])
@@ -1025,17 +1025,17 @@ mod tests {
 
     #[test]
     fn test_tensor_prod_2d_2d() {
-        let shape1 = shape![2, 2].unwrap();
+        let shape1 = shape![2, 2];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let tensor1 = Tensor::new(&shape1, &data1).unwrap();
 
-        let shape2 = shape![2, 2].unwrap();
+        let shape2 = shape![2, 2];
         let data2 = vec![5.0, 6.0, 7.0, 8.0];
         let tensor2 = Tensor::new(&shape2, &data2).unwrap();
 
         let result = tensor1.prod(&tensor2);
 
-        assert_eq!(result.shape(), &shape![2, 2, 2, 2].unwrap());
+        assert_eq!(result.shape(), &shape![2, 2, 2, 2]);
         assert_eq!(
             result.data,
             DynamicStorage::new(vec![
@@ -1047,7 +1047,7 @@ mod tests {
 
     #[test]
     fn test_add_tensor() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let tensor1 = Tensor::new(&shape, &data1).unwrap();
 
@@ -1059,7 +1059,7 @@ mod tests {
 
     #[test]
     fn test_add_tensors() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![5.0, 6.0, 7.0, 8.0];
         let tensor1 = Tensor::new(&shape, &data1).unwrap();
@@ -1073,7 +1073,7 @@ mod tests {
 
     #[test]
     fn test_sub_tensor() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![5.0, 6.0, 7.0, 8.0];
 
         let tensor1 = Tensor::new(&shape, &data1).unwrap();
@@ -1086,7 +1086,7 @@ mod tests {
 
     #[test]
     fn test_sub_tensors() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![5.0, 6.0, 7.0, 8.0];
         let data2 = vec![1.0, 2.0, 3.0, 4.0];
         let tensor1 = Tensor::new(&shape, &data1).unwrap();
@@ -1100,7 +1100,7 @@ mod tests {
 
     #[test]
     fn test_mul_tensor() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
 
         let tensor1 = Tensor::new(&shape, &data1).unwrap();
@@ -1113,7 +1113,7 @@ mod tests {
 
     #[test]
     fn test_div_tensor() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![4.0, 6.0, 8.0, 10.0];
 
         let tensor1 = Tensor::new(&shape, &data1).unwrap();
@@ -1126,7 +1126,7 @@ mod tests {
 
     #[test]
     fn test_vec_vec_mul_single() {
-        let shape = shape![1].unwrap();
+        let shape = shape![1];
         let data1 = vec![2.0];
         let data2 = vec![5.0];
 
@@ -1135,13 +1135,13 @@ mod tests {
 
         let result = tensor1 * tensor2;
 
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
         assert_eq!(result.data, DynamicStorage::new(vec![10.0]));
     }
 
     #[test]
     fn test_vec_vec_mul() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
 
@@ -1156,8 +1156,8 @@ mod tests {
 
     #[test]
     fn test_matrix_matrix_mul() {
-        let shape1 = shape![2, 3].unwrap();
-        let shape2 = shape![2, 3].unwrap();
+        let shape1 = shape![2, 3];
+        let shape2 = shape![2, 3];
         let data1 = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let data2 = vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0];
 
@@ -1166,7 +1166,7 @@ mod tests {
 
         let result = tensor1 * tensor2;
 
-        assert_eq!(result.shape(), &shape![2, 3].unwrap());
+        assert_eq!(result.shape(), &shape![2, 3]);
         assert_eq!(
             result.data,
             DynamicStorage::new(vec![7.0, 16.0, 27.0, 40.0, 55.0, 72.0])
@@ -1175,7 +1175,7 @@ mod tests {
 
     #[test]
     fn test_add_tensor_vector() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let tensor = DynamicTensor::new(&shape, &data1).unwrap();
@@ -1190,7 +1190,7 @@ mod tests {
 
     #[test]
     fn test_sub_tensor_vector() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![2.0, 3.0, 4.0, 5.0];
         let data2 = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = DynamicTensor::new(&shape, &data1).unwrap();
@@ -1205,7 +1205,7 @@ mod tests {
 
     #[test]
     fn test_mul_tensor_vector() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![2.0, 3.0, 4.0, 5.0];
         let data2 = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = DynamicTensor::new(&shape, &data1).unwrap();
@@ -1220,7 +1220,7 @@ mod tests {
 
     #[test]
     fn test_div_tensor_vector() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![2.0, 4.0, 6.0, 8.0];
         let data2 = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = DynamicTensor::new(&shape, &data1).unwrap();
@@ -1235,67 +1235,67 @@ mod tests {
 
     #[test]
     fn test_add_tensor_matrix() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let tensor = DynamicTensor::new(&shape, &data1).unwrap();
         let matrix = DynamicMatrix::new(&shape, &data2).unwrap();
         let result = tensor + matrix;
-        assert_eq!(result[coord![0, 0].unwrap()], 3.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 5.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 7.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 9.0);
+        assert_eq!(result[coord![0, 0]], 3.0);
+        assert_eq!(result[coord![0, 1]], 5.0);
+        assert_eq!(result[coord![1, 0]], 7.0);
+        assert_eq!(result[coord![1, 1]], 9.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_sub_tensor_matrix() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![2.0, 3.0, 4.0, 5.0];
         let data2 = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = DynamicTensor::new(&shape, &data1).unwrap();
         let matrix = DynamicMatrix::new(&shape, &data2).unwrap();
         let result = tensor - matrix;
-        assert_eq!(result[coord![0, 0].unwrap()], 1.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 1.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 1.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 1.0);
+        assert_eq!(result[coord![0, 0]], 1.0);
+        assert_eq!(result[coord![0, 1]], 1.0);
+        assert_eq!(result[coord![1, 0]], 1.0);
+        assert_eq!(result[coord![1, 1]], 1.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_mul_tensor_matrix() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![2.0, 3.0, 4.0, 5.0];
         let data2 = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = DynamicTensor::new(&shape, &data1).unwrap();
         let matrix = DynamicMatrix::new(&shape, &data2).unwrap();
         let result = tensor * matrix;
-        assert_eq!(result[coord![0, 0].unwrap()], 2.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 6.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 12.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 20.0);
+        assert_eq!(result[coord![0, 0]], 2.0);
+        assert_eq!(result[coord![0, 1]], 6.0);
+        assert_eq!(result[coord![1, 0]], 12.0);
+        assert_eq!(result[coord![1, 1]], 20.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_div_tensor_matrix() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data1 = vec![2.0, 4.0, 6.0, 8.0];
         let data2 = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = DynamicTensor::new(&shape, &data1).unwrap();
         let matrix = DynamicMatrix::new(&shape, &data2).unwrap();
         let result = tensor / matrix;
-        assert_eq!(result[coord![0, 0].unwrap()], 2.0);
-        assert_eq!(result[coord![0, 1].unwrap()], 2.0);
-        assert_eq!(result[coord![1, 0].unwrap()], 2.0);
-        assert_eq!(result[coord![1, 1].unwrap()], 2.0);
+        assert_eq!(result[coord![0, 0]], 2.0);
+        assert_eq!(result[coord![0, 1]], 2.0);
+        assert_eq!(result[coord![1, 0]], 2.0);
+        assert_eq!(result[coord![1, 1]], 2.0);
         assert_eq!(result.shape(), &shape);
     }
 
     #[test]
     fn test_display_1d_tensor() {
-        let shape = shape![3].unwrap();
+        let shape = shape![3];
         let data = vec![1.0, 2.0, 3.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
         let display = tensor.display();
@@ -1304,7 +1304,7 @@ mod tests {
 
     #[test]
     fn test_display_2d_tensor() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
         let display = tensor.display();
@@ -1313,7 +1313,7 @@ mod tests {
 
     #[test]
     fn test_display_3d_tensor() {
-        let shape = shape![2, 2, 2].unwrap();
+        let shape = shape![2, 2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
         let display = tensor.display();
@@ -1322,7 +1322,7 @@ mod tests {
 
     #[test]
     fn test_display_4d_tensor() {
-        let shape = shape![2, 2, 2, 2].unwrap();
+        let shape = shape![2, 2, 2, 2];
         let data = vec![
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         ];
@@ -1333,7 +1333,7 @@ mod tests {
 
     #[test]
     fn test_pow_tensor_square() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
         let result = tensor.pow(2.0);
@@ -1343,7 +1343,7 @@ mod tests {
 
     #[test]
     fn test_pow_tensor_sqrt() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 4.0, 9.0, 16.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
         let result = tensor.pow(0.5);
@@ -1353,7 +1353,7 @@ mod tests {
 
     #[test]
     fn test_pow_tensor_negative_exponent() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 4.0, 8.0];
         let tensor = Tensor::new(&shape, &data).unwrap();
         let result = tensor.pow(-1.0);

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -17,7 +17,7 @@ pub type Vector<T> = DynamicVector<T>;
 impl<T: Num + PartialOrd + Copy> DynamicVector<T> {
     pub fn new(data: &[T]) -> Result<DynamicVector<T>, ShapeError> {
         Ok(DynamicVector {
-            tensor: DynamicTensor::new(&shape![data.len()].unwrap(), data)?,
+            tensor: DynamicTensor::new(&shape![data.len()], data)?,
         })
     }
 
@@ -79,13 +79,13 @@ impl<T: Num + PartialOrd + Copy> DynamicVector<T> {
 
     pub fn matmul(&self, rhs: &DynamicMatrix<T>) -> DynamicVector<T> {
         assert_eq!(self.shape()[0], rhs.shape()[0]);
-        let mut result = DynamicTensor::zeros(&shape![rhs.shape()[1]].unwrap());
+        let mut result = DynamicTensor::zeros(&shape![rhs.shape()[1]]);
         for j in 0..rhs.shape()[1] {
             let mut sum = T::zero();
             for i in 0..self.shape()[0] {
-                sum = sum + self[i] * rhs[coord![i, j].unwrap()];
+                sum = sum + self[i] * rhs[coord![i, j]];
             }
-            result.set(&coord![j].unwrap(), sum).unwrap();
+            result.set(&coord![j], sum).unwrap();
         }
         DynamicVector::from_tensor(result).unwrap()
     }
@@ -219,13 +219,13 @@ impl<T: Num + Copy + PartialOrd> Index<usize> for DynamicVector<T> {
     type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {
-        self.tensor.get(&coord![index].unwrap()).unwrap()
+        self.tensor.get(&coord![index]).unwrap()
     }
 }
 
 impl<T: Num + Copy + PartialOrd> IndexMut<usize> for DynamicVector<T> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        self.tensor.get_mut(&coord![index].unwrap()).unwrap()
+        self.tensor.get_mut(&coord![index]).unwrap()
     }
 }
 
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let vector = DynamicVector::new(&data).unwrap();
         assert_eq!(vector.shape(), &shape);
@@ -247,7 +247,7 @@ mod tests {
 
     #[test]
     fn test_from_tensor() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = DynamicTensor::new(&shape, &data).unwrap();
         let vector = DynamicVector::from_tensor(tensor).unwrap();
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn test_from_tensor_fail() {
-        let shape = shape![2, 2].unwrap();
+        let shape = shape![2, 2];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let tensor = DynamicTensor::new(&shape, &data).unwrap();
         let result = DynamicVector::from_tensor(tensor);
@@ -269,7 +269,7 @@ mod tests {
 
     #[test]
     fn test_fill() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let vector = DynamicVector::fill(&shape, 3.0).unwrap();
         assert_eq!(vector.shape(), &shape);
         assert_eq!(vector[0], 3.0);
@@ -280,7 +280,7 @@ mod tests {
 
     #[test]
     fn test_zeros() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let vector = DynamicVector::<f64>::zeros(&shape).unwrap();
         assert_eq!(vector.shape(), &shape);
         assert_eq!(vector[0], 0.0);
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn test_ones() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let vector = DynamicVector::<f64>::ones(&shape).unwrap();
         assert_eq!(vector.shape(), &shape);
         assert_eq!(vector[0], 1.0);
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn test_size() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let vector = DynamicVector::<f64>::zeros(&shape).unwrap();
         assert_eq!(vector.size(), 4);
     }
@@ -326,8 +326,8 @@ mod tests {
     fn test_set() {
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let mut vector = DynamicVector::new(&data).unwrap();
-        vector.set(&coord![2].unwrap(), 5.0).unwrap();
-        assert_eq!(*vector.get(&coord![2].unwrap()).unwrap(), 5.0);
+        vector.set(&coord![2], 5.0).unwrap();
+        assert_eq!(*vector.get(&coord![2]).unwrap(), 5.0);
     }
 
     #[test]
@@ -336,7 +336,7 @@ mod tests {
         let vector = DynamicVector::new(&data).unwrap();
         let result = vector.sum();
         assert_eq!(result[0], 10.0);
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
     }
 
     #[test]
@@ -345,7 +345,7 @@ mod tests {
         let vector = DynamicVector::new(&data).unwrap();
         let result = vector.mean();
         assert_eq!(result[0], 2.5);
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
     }
 
     #[test]
@@ -354,7 +354,7 @@ mod tests {
         let vector = DynamicVector::new(&data).unwrap();
         let result = vector.var();
         assert_eq!(result[0], 1.25);
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
     }
 
     #[test]
@@ -363,7 +363,7 @@ mod tests {
         let vector = DynamicVector::new(&data).unwrap();
         let result = vector.min();
         assert_eq!(result[0], 1.0);
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
     }
 
     #[test]
@@ -372,7 +372,7 @@ mod tests {
         let vector = DynamicVector::new(&data).unwrap();
         let result = vector.max();
         assert_eq!(result[0], -1.0);
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
     }
 
     #[test]
@@ -383,7 +383,7 @@ mod tests {
         let vector2 = DynamicVector::new(&data2).unwrap();
         let result = vector1.vecmul(&vector2);
         assert_eq!(result[0], 40.0);
-        assert_eq!(result.shape(), &shape![1].unwrap());
+        assert_eq!(result.shape(), &shape![1]);
     }
 
     #[test]
@@ -391,9 +391,9 @@ mod tests {
         let data_vector = vec![1.0, 2.0];
         let data_matrix = vec![1.0, 2.0, 3.0, 4.0];
         let vector = DynamicVector::new(&data_vector).unwrap();
-        let matrix = DynamicMatrix::new(&shape![2, 2].unwrap(), &data_matrix).unwrap();
+        let matrix = DynamicMatrix::new(&shape![2, 2], &data_matrix).unwrap();
         let result = vector.matmul(&matrix);
-        assert_eq!(result.shape(), &shape![2].unwrap());
+        assert_eq!(result.shape(), &shape![2]);
         assert_eq!(result[0], 7.0);
         assert_eq!(result[1], 10.0);
     }
@@ -409,14 +409,14 @@ mod tests {
         let expected_data = vec![
             2.0, 3.0, 4.0, 5.0, 4.0, 6.0, 8.0, 10.0, 6.0, 9.0, 12.0, 15.0, 8.0, 12.0, 16.0, 20.0,
         ];
-        let expected_shape = shape![4, 4].unwrap();
+        let expected_shape = shape![4, 4];
         let expected_tensor = DynamicTensor::new(&expected_shape, &expected_data).unwrap();
 
         assert_eq!(result.shape(), &expected_shape);
         for i in 0..result.shape()[0] {
             for j in 0..result.shape()[1] {
-                let x = result.get(&coord![i, j].unwrap()).unwrap();
-                let y = expected_tensor.get(&coord![i, j].unwrap()).unwrap();
+                let x = result.get(&coord![i, j]).unwrap();
+                let y = expected_tensor.get(&coord![i, j]).unwrap();
                 assert_eq!(*x, *y);
             }
         }
@@ -431,12 +431,12 @@ mod tests {
         assert_eq!(result[1], 4.0);
         assert_eq!(result[2], 5.0);
         assert_eq!(result[3], 6.0);
-        assert_eq!(result.shape(), &shape![4].unwrap());
+        assert_eq!(result.shape(), &shape![4]);
     }
 
     #[test]
     fn test_add_vector() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let vector1 = DynamicVector::new(&data1).unwrap();
@@ -451,7 +451,7 @@ mod tests {
 
     #[test]
     fn test_add_vector_tensor() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let vector = DynamicVector::new(&data1).unwrap();
@@ -466,7 +466,7 @@ mod tests {
 
     #[test]
     fn test_sub_scalar() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let vector = DynamicVector::new(&data).unwrap();
         let result = vector - 2.0;
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn test_sub_vector() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let vector1 = DynamicVector::new(&data1).unwrap();
@@ -494,7 +494,7 @@ mod tests {
 
     #[test]
     fn test_sub_vector_tensor() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let vector = DynamicVector::new(&data1).unwrap();
@@ -509,7 +509,7 @@ mod tests {
 
     #[test]
     fn test_mul_scalar() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data = vec![1.0, 2.0, 3.0, 4.0];
         let vector = DynamicVector::new(&data).unwrap();
         let result = vector * 2.0;
@@ -522,7 +522,7 @@ mod tests {
 
     #[test]
     fn test_mul_vector() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let vector1 = DynamicVector::new(&data1).unwrap();
@@ -537,7 +537,7 @@ mod tests {
 
     #[test]
     fn test_mul_vector_tensor() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![1.0, 2.0, 3.0, 4.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let vector = DynamicVector::new(&data1).unwrap();
@@ -552,7 +552,7 @@ mod tests {
 
     #[test]
     fn test_div_scalar() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data = vec![4.0, 6.0, 8.0, 10.0];
         let vector = DynamicVector::new(&data).unwrap();
         let result = vector / 2.0;
@@ -565,7 +565,7 @@ mod tests {
 
     #[test]
     fn test_div_vector() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![4.0, 6.0, 8.0, 10.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let vector1 = DynamicVector::new(&data1).unwrap();
@@ -580,7 +580,7 @@ mod tests {
 
     #[test]
     fn test_div_vector_tensor() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data1 = vec![4.0, 6.0, 8.0, 10.0];
         let data2 = vec![2.0, 3.0, 4.0, 5.0];
         let vector = DynamicVector::new(&data1).unwrap();
@@ -595,7 +595,7 @@ mod tests {
 
     #[test]
     fn test_pow_vector() {
-        let shape = shape![4].unwrap();
+        let shape = shape![4];
         let data = vec![2.0, 3.0, 4.0, 5.0];
         let vector = DynamicVector::new(&data).unwrap();
         let result = vector.pow(2.0);


### PR DESCRIPTION
The thought is: use `new` if you want control over error handling. Use `macro` for conciseness.